### PR TITLE
Replace createMock() with createStub() where no expectations needed

### DIFF
--- a/app/tests/Api/TvdbAuthClientTest.php
+++ b/app/tests/Api/TvdbAuthClientTest.php
@@ -50,7 +50,7 @@ class TvdbAuthClientTest extends TestCase
     public function testLoginThrowsExceptionOnTransportException(): void
     {
         $this->client->expects('request')
-            ->andThrows($this->createMock(TransportExceptionInterface::class));
+            ->andThrows($this->createStub(TransportExceptionInterface::class));
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Error while logging in');

--- a/app/tests/Api/TvdbQueryClientTest.php
+++ b/app/tests/Api/TvdbQueryClientTest.php
@@ -57,7 +57,7 @@ class TvdbQueryClientTest extends TestCase
             ->andReturns('token');
 
         $this->client->expects('request')
-            ->andThrows($this->createMock(TransportExceptionInterface::class));
+            ->andThrows($this->createStub(TransportExceptionInterface::class));
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Error while searching');
@@ -89,7 +89,7 @@ class TvdbQueryClientTest extends TestCase
             ->andReturns('token');
 
         $this->client->expects('request')
-            ->andThrows($this->createMock(TransportExceptionInterface::class));
+            ->andThrows($this->createStub(TransportExceptionInterface::class));
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Error while getting extended series data');
@@ -121,7 +121,7 @@ class TvdbQueryClientTest extends TestCase
             ->andReturns('token');
 
         $this->client->expects('request')
-            ->andThrows($this->createMock(TransportExceptionInterface::class));
+            ->andThrows($this->createStub(TransportExceptionInterface::class));
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Error while getting extended season data');

--- a/app/tests/Cache/TvdbApiTokenCacheTest.php
+++ b/app/tests/Cache/TvdbApiTokenCacheTest.php
@@ -57,7 +57,7 @@ class TvdbApiTokenCacheTest extends TestCase
     public function testGetTokenThrowsExceptionOnInvalidArgumentException(): void
     {
         $this->cache->expects('get')
-            ->andThrows($this->createMock(InvalidArgumentException::class));
+            ->andThrows($this->createStub(InvalidArgumentException::class));
 
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Error getting token from cache');

--- a/app/tests/Repository/SeriesTest.php
+++ b/app/tests/Repository/SeriesTest.php
@@ -5,6 +5,8 @@ namespace App\Tests\Repository;
 use App\Document\Episode as EpisodeDocument;
 use App\Document\History;
 use App\Repository\Series;
+use DateTime;
+use DateTimeImmutable;
 use DG\BypassFinals;
 use Doctrine\ODM\MongoDB\Aggregation\Aggregation;
 use Doctrine\ODM\MongoDB\Aggregation\Builder;
@@ -365,15 +367,15 @@ class SeriesTest extends TestCase
         $iteratorMock2 = Mockery::mock(Iterator::class);
         $aggregationMock2->expects('getIterator')->andReturn($iteratorMock2);
 
-        $past = new \DateTime('-1 day');
-        $future = new \DateTime('+1 day');
+        $past = new DateTime('-1 day');
+        $future = new DateTime('+1 day');
         $iteratorMock2->expects('toArray')->andReturn([
             ['_id' => ['seriesTitle' => 'series1', 'season' => 1], 'maxAirDate' => $past],
             ['_id' => ['seriesTitle' => 'series2', 'season' => 2], 'maxAirDate' => $future],
             ['_id' => ['seriesTitle' => 'series3', 'season' => 1], 'maxAirDate' => $past],
         ]);
 
-        $now = new \DateTimeImmutable();
+        $now = new DateTimeImmutable();
         $result = $this->unit->getSeriesTitlesWithAvailableCurrentSeason($now);
 
         // series1 season 1 aired in past → available
@@ -408,6 +410,6 @@ class SeriesTest extends TestCase
         $aggregationMock->expects('getIterator')->andReturn($iteratorMock);
         $iteratorMock->expects('toArray')->andReturn([]);
 
-        $this->assertSame([], $this->unit->getSeriesTitlesWithAvailableCurrentSeason(new \DateTimeImmutable()));
+        $this->assertSame([], $this->unit->getSeriesTitlesWithAvailableCurrentSeason(new DateTimeImmutable()));
     }
 }


### PR DESCRIPTION
PHPUnit 13 emits a notice when createMock() is used without configuring any expectations. These mocks are only thrown as exceptions so createStub() is the correct method.